### PR TITLE
Alert Symbol Not Displayed When showHeaderInStopTime is False

### DIFF
--- a/MMM-Futar.js
+++ b/MMM-Futar.js
@@ -179,7 +179,7 @@ Module.register('MMM-Futar', {
     absoluteTimeEl.innerHTML = ` (${departureTime.absoluteTime})`;
     timeEl.appendChild(absoluteTimeEl);
 
-    if (this.config.alerts.showHeaderInStopTime && departureTime.alertHeader) {
+    if (departureTime.alertHeader && (this.config.alerts.showHeaderInStopTime || this.config.alerts.showSymbolInStopTime)) {
       const alertEl = this._getDomForAlertHeaderInStopTime(departureTime.alertHeader);
       timeEl.appendChild(alertEl);
     }
@@ -222,10 +222,12 @@ Module.register('MMM-Futar', {
       alertEl.appendChild(alertSymbolEl);
     }
 
-    const alertTextEl = document.createElement('span');
-    alertTextEl.classList = 'alert-header';
-    alertTextEl.innerHTML = alertHeader;
-    alertEl.appendChild(alertTextEl);
+    if (this.config.alerts.showHeaderInStopTime)
+      const alertTextEl = document.createElement('span');
+      alertTextEl.classList = 'alert-header';
+      alertTextEl.innerHTML = alertHeader;
+      alertEl.appendChild(alertTextEl);
+    }
 
     return alertEl;
   },


### PR DESCRIPTION
## Description
The `showSymbolInStopTime` configuration option in the `alerts` section does not work independently. When `showHeaderInStopTime` is set to `false`, the alert symbol is not displayed even if `showSymbolInStopTime` is set to `true`.

## Expected Behavior
The alert symbol and alert header text should be independently controllable through their respective configuration options:
- When `showSymbolInStopTime: true` and `showHeaderInStopTime: false`, only the alert symbol should be displayed
- When `showSymbolInStopTime: false` and `showHeaderInStopTime: true`, only the alert header text should be displayed
- When both are `true`, both should be displayed
- When both are `false`, neither should be displayed

## Actual Behavior
The alert symbol is only displayed when `showHeaderInStopTime: true`, regardless of the `showSymbolInStopTime` setting.

## Configuration Example
```js
alerts: {
  showHeaderInStopTime: false,
  showSymbolInStopTime: true  // This setting has no effect
}
```

## Root Cause
In the `_getDomForDepartureTime` method, the alert element is only created when `showHeaderInStopTime` is true:

```js
if (this.config.alerts.showHeaderInStopTime && departureTime.alertHeader) {
  const alertEl = this._getDomForAlertHeaderInStopTime(departureTime.alertHeader);
  timeEl.appendChild(alertEl);
}
```

The `_getDomForAlertHeaderInStopTime` method contains the logic for displaying the symbol, but it's never called when `showHeaderInStopTime` is false.

## Suggested Fix
Modify the condition to check if either option is enabled, and add conditional logic inside `_getDomForAlertHeaderInStopTime` to render each element independently.

## After the fix screenshot
<img width="241" height="124" alt="image" src="https://github.com/user-attachments/assets/b3cb1205-5501-4494-8e1a-3c1a46dc228b" />