### PR TITLE
Incorrect Stop Times Displayed Due to Missing stopId Validation

### DIFF
--- a/MMM-Futar.js
+++ b/MMM-Futar.js
@@ -301,6 +301,11 @@ Module.register('MMM-Futar', {
     const stopTimes = this._getAllStopTimesFromResponse(response);
     for (let i = 0; i < stopTimes.length; i++) {
       const stopTime = stopTimes[i];
+
+      if (this.config.stopId && stopTime.stopId !== this.config.stopId) {
+        continue;
+      }
+      
       const tripId = this._getTripIdFromStopTime(stopTime);
       const trip = this._getTripById(trips, tripId);
       const routeId = this._getRouteIdFromTrip(trip);


### PR DESCRIPTION
## Description
The module displays departure times from stops that don't match the configured `stopId`. When the API returns data for multiple stops (possibly due to API errors or nearby stops), all stop times are displayed regardless of whether they belong to the configured stop.

## Expected Behavior
Only departure times for the stop specified in `config.stopId` should be displayed. Any stop times from different stops returned by the API should be filtered out.

## Actual Behavior
All stop times returned by the API are displayed, even if their `stopId` doesn't match the configured `stopId`. This can lead to:
- Incorrect departure information being shown
- Confusion when nearby stops have similar routes
- Displaying data from unintended stops when API returns unexpected results

## Configuration Example
```js
config: {
  stopId: 'BKK_09183209',
  // ... other config
}
```

## API Response Example
The API sometimes returns stop times with different `stopId` values:
```json
{
  "stopTimes": [
    {
      "stopId": "BKK_09183209",  // Correct stop
      "stopHeadsign": "Batthyány tér",
      ...
    },
    {
      "stopId": "BKK_09183208",  // Different stop - should be filtered
      "stopHeadsign": "Szentendre",
      ...
    }
  ]
}
```
https://futar.bkk.hu/api/query/v1/ws/otp/api/where/arrivals-and-departures-for-stop.json?stopId=BKK_09183209&routeId=BKK_H5&onlyDepartures=true&minutesBefore=0&minutesAfter=40&key=APIKEY

## Root Cause
In the `_processResponseJson` method, there is no validation to ensure that `stopTime.stopId` matches `config.stopId`. The method only checks `routeId` but not `stopId`:

```js
if (!this.config.routeId || routeId === this.config.routeId) {
  // Process stop time without checking stopId
}
```

## Suggested Fix
Add stopId validation at the beginning of the stopTimes loop to skip processing stop times that don't match the configured stopId.

## Before the fix screenshot
<img width="204" height="150" alt="image" src="https://github.com/user-attachments/assets/273be896-11f2-441a-b4b0-40d25bae7aff" />

## After the fix screenshot
<img width="204" height="146" alt="image" src="https://github.com/user-attachments/assets/69202a16-d93f-4df2-a002-314c84c5a64a" />

